### PR TITLE
Adding fallback for MP3 files when their mime type can't be inferred

### DIFF
--- a/src/transcribe.rs
+++ b/src/transcribe.rs
@@ -36,11 +36,23 @@ pub async fn transcribe_audio(
             "audio/wav" => MediaFormat::Wav,
             "audio/webm" => MediaFormat::Webm,
             _ => {
-                bail!("\nUnsupported media format: {}", kind.mime_type());
+                // Fallback to checking the file extension (MP3s sometimes cause issues)
+                match file_path.extension().and_then(|ext| ext.to_str()) {
+                    Some("mp3") => MediaFormat::Mp3,
+                    _ => {
+                        bail!("\nUnsupported media format: {}", kind.mime_type());
+                    }
+                }
             }
         },
         Ok(None) => {
-            bail!("\nUnable to determine media format from file extension");
+            // Fallback to checking the file extension
+            match file_path.extension().and_then(|ext| ext.to_str()) {
+                Some("mp3") => MediaFormat::Mp3,
+                _ => {
+                    bail!("\nUnable to determine media format from file extension");
+                }
+            }
         }
         Err(err) => {
             bail!("\nError determining media format: {}", err);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Some MP3 files are not being inferred correctly by the infer crate. They should resolve to "audio/mpeg", but are not. This is a fix to handle those cases by inferring the type from the extension.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
