### PR TITLE
fix: add support to `.ogg` files with `audio/opus` mime type which is supported by AWS Transcribe 

### DIFF
--- a/src/transcribe.rs
+++ b/src/transcribe.rs
@@ -34,6 +34,7 @@ pub async fn transcribe_audio(
             "audio/mp4" => MediaFormat::Mp4,
             "video/mp4" => MediaFormat::Mp4,
             "audio/ogg" => MediaFormat::Ogg,
+            "audio/opus" => MediaFormat::Ogg,
             "audio/wav" => MediaFormat::Wav,
             "audio/webm" => MediaFormat::Webm,
             _ => {


### PR DESCRIPTION
### Overview
Got this error while trying the tool with an `*.ogg` audio file :
> ⠐ Using bucket region us-west-2  
>⠈ Submitting transcription jobError:  
>Unsupported media format: audio/opus

a mime type `audio/opus` is probably just an opus file without a wrapper ogg container  
ref: https://wiki.xiph.org/MIME_Types_and_File_Extensions


AWS Transcribe supports ogg files, an audio file with `audio/opus` mime type is successfully transcribed
ref: https://docs.aws.amazon.com/transcribe/latest/dg/how-input.html#how-input-audio

This change adds the mapping `audio/opus` to `MediaFormat::Ogg`.

### Testing:
Tested successfully with an `*.ogg` file with `audio/opus` mime type