### PR TITLE
Added s3 flag to delete audio file onto Amazon S3 post processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Like the [Amazon Bedrock Audio Summarizer](https://github.com/aws-samples/amazon
 
 Distill CLI supports configurable language codes for transcription using Amazon Transcribe. Specify the language of the audio file with the `--language-code` or `-l` parameter (e.g., `--language-code es-US` for Spanish). If no language code is provided, it defaults to English (United States) (`en-US`). For a list of supported languages and their codes, see the [Amazon Transcribe Supported Languages Documentation](https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html). Use `--help` for more information on available options. The prompt in the provided config.toml is adjusted so that the provided output matches the language in the transcript.
 
+# S3 Object Deletion
+
+Distill CLI supports deletion of the audio recodings once transcribe and summarize activities performed with success. By using the `--delete-s3-object` or `-d` parameter (e.g., `--delete-s3-object Y`), the audio file previously uploaded onto Amazon S3 will be deleted. Use `--help` for more information on available options.
+
 # A note on regions
 
 By default, the Distill CLI inherits credentials and configuration details from the AWS CLI. Since Bedrock is not yet available in every region, ensure that the default region in your AWS config is on the list of [supported Bedrock regions](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html). 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Distill CLI supports configurable language codes for transcription using Amazon 
 
 # S3 Object Deletion
 
-Distill CLI supports deletion of the audio recodings once transcribe and summarize activities performed with success. By using the `--delete-s3-object` or `-d` parameter (e.g., `--delete-s3-object Y`), the audio file previously uploaded onto Amazon S3 will be deleted. Use `--help` for more information on available options.
+Distill CLI supports the deletion of audio recordings after transcription and summarization activities have completed. Using the `--delete-s3-object` or `-d` parameter (e.g., `--delete-s3-object Y`), the audio file previously uploaded onto Amazon S3 will be deleted. Use `--help` for more information on available options.
 
 # A note on regions
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/distill-cli/issues/8

*Description of changes:*
I updated **main.rs** file and added a new clap named `delete_s3_object` with a default value set to `n` If the user provides `Y` value, it will execute the expression row#293 which will delete the object from Amazon S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
