### PR TITLE
(fix) Enable logging; fix large videos on slow connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,13 @@ license = "Apache-2.0"
 include = ["src/**/*", "config.toml"]
 
 [dependencies]
+log = "0.4.22"
+env_logger = "0.11.5"
 anyhow = "1.0.82"
-aws-config = { version = "1.1.7", features = ["behavior-version-latest" ] }
-aws-sdk-bedrockruntime = "1.23.0"
-aws-sdk-s3 = "1.24.0"
-aws-sdk-transcribe = "1.21.0"
+aws-config = { version = "1.5.5", features = ["behavior-version-latest" ] }
+aws-sdk-bedrockruntime = "1.44.0"
+aws-sdk-s3 = "1.44.0"
+aws-sdk-transcribe = "1.39.0"
 aws-types = "0.14.0"
 clap = { version = "4.5.4", features = ["derive"] }
 config = "0.13.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use aws_config::meta::region::RegionProviderChain;
 use aws_config::{Region, SdkConfig};
+use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use clap::Parser;
 use config::{Config, File as ConfigFile};
 use docx_rs::{Docx, Paragraph, Run};
@@ -52,6 +53,7 @@ enum OutputType {
 
 #[::tokio::main]
 async fn main() -> Result<()> {
+    env_logger::init();
     let config = load_config(None).await;
 
     let settings = Config::builder()
@@ -291,6 +293,14 @@ async fn load_config(region: Option<Region>) -> SdkConfig {
             config = config.region(RegionProviderChain::default_provider().or_else("us-east-1"))
         }
     }
+
+    // Resolves issues with uploading large S3 files
+    // See https://github.com/awslabs/aws-sdk-rust/issues/1146
+    config = config
+        .stalled_stream_protection(
+            StalledStreamProtectionConfig::disabled()
+        );
+
     config.load().await
 }
 


### PR DESCRIPTION
*Description of changes:*

When uploading large videos to the s3 bucket (~200mb) on a slow uplink (2 Mb/s) a stall protection for upload kick in.

This protection incorrectly detects stalled upload and panics, even on active uploads healthy uploads.

See https://github.com/awslabs/aws-sdk-rust/issues/1146

Crate changes:

- add log and env_logger to aid debugging and root causing
- update aws-sdk to latest

Testing:

RUST_LOG=debug cargo run -- -i "~/Downloads/meeting.mp4" -o text

*Issue:*

```

RUST_LOG=debug cargo run --  -o text -i ~/Downloads/not_so_humongous_video.mp4

[2024-08-16T16:00:21Z DEBUG hyper::proto::h1::io] flushed 4096 bytes
[2024-08-16T16:00:21Z DEBUG hyper::proto::h1::io] flushed 4096 bytes
[2024-08-16T16:00:21Z DEBUG hyper::proto::h1::io] flushed 4096 bytes
[2024-08-16T16:00:21Z DEBUG hyper::proto::h1::io] flushed 4096 bytes
[2024-08-16T16:00:21Z DEBUG hyper::proto::h1::io] flushed 4096 bytes
[2024-08-16T16:00:21Z DEBUG hyper::proto::h1::io] flushed 3732 bytes
⠦ Using bucket region us-east-1[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] current throughput: 0 B/s is below minimum: 1 B/s
[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] current throughput: 0 B/s is below minimum: 1 B/s
⠖ Using bucket region us-east-1[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] current throughput: 0 B/s is below minimum: 1 B/s
[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] current throughput: 0 B/s is below minimum: 1 B/s
⠒ Using bucket region us-east-1[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] current throughput: 0 B/s is below minimum: 1 B/s
[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] current throughput: 0 B/s is below minimum: 1 B/s
⠐ Using bucket region us-east-1[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] current throughput: 0 B/s is below minimum: 1 B/s
[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::http::body::minimum_throughput] grace period ended; timing out request
[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::orchestrator] encountered orchestrator error; halting
[2024-08-16T16:00:21Z DEBUG tracing::span] finally_attempt;
[2024-08-16T16:00:21Z DEBUG rustls::common_state] Sending warning alert CloseNotify
[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::retries::strategy::standard] not retrying because we are out of attempts attempts=3 max_attempts=3
[2024-08-16T16:00:21Z DEBUG aws_smithy_runtime::client::orchestrator] a retry is either unnecessary or not possible, exiting attempt loop
[2024-08-16T16:00:21Z DEBUG tracing::span] finally_op;
Error: Failed to upload to S3

Caused by:
    0: dispatch failure
    1: timeout
    2: minimum throughput was specified at 1 B/s, but throughput of 0 B/s was observed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
